### PR TITLE
Handle malformed response JSON

### DIFF
--- a/lib/ailurus/dataset/metadata.rb
+++ b/lib/ailurus/dataset/metadata.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module Ailurus
   class Dataset
     # Public: Retrieve metadata about this Dataset.
@@ -7,7 +9,11 @@ module Ailurus
     # Returns a Hash.
     def metadata
       endpoint = "/api/1.0/dataset/#{@slug}/"
-      @client.make_request(endpoint)
+      begin
+        @client.make_request(endpoint)
+      rescue JSON::JSONError
+        nil
+      end
     end
 
     # Public: Get the indexed name for a field so you can perform more detailed

--- a/spec/ailurus/dataset/metadata_spec.rb
+++ b/spec/ailurus/dataset/metadata_spec.rb
@@ -10,6 +10,14 @@ describe Ailurus::Dataset do
       expect_url("http://panda.example.com/api/1.0/dataset/example/")
     end
 
+    it "responds appropriately to malformed input" do
+      stub_request(:any, /panda\.example\.com/).to_return(:body => "{}")
+      client = make_test_client
+      allow(client).to receive(:make_request).and_raise(JSON::ParserError)
+      test_metadata = client.dataset("example").metadata
+      expect(test_metadata).to be(nil)
+    end
+
     it "looks up indexed field names" do
       stub_request(:any, /panda\.example\.com/).to_return(
         :body => JSON.generate({


### PR DESCRIPTION
Ran into some of this with a 404 (for a missing dataset) when testing against a local PANDA installation. This should resolve the error.

Minor fix, but might as well do this as a PR so I can run it through Travis. (And it's just good practice.)
