### PR TITLE
Properly handle `IPv4:port` addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.2.1
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
   - 1.9.3
 notifications:
   email: false

--- a/lib/ailurus/utils.rb
+++ b/lib/ailurus/utils.rb
@@ -9,11 +9,19 @@ module Ailurus
     #
     # Returns a URI::HTTP instance.
     def self.get_absolute_uri(domain_string)
-      uri = URI(domain_string)
-      if not uri.is_a?(URI::HTTP)
-        uri = URI("http://#{domain_string}")
+      begin
+        uri = URI(domain_string)
+        if not uri.is_a?(URI::HTTP)
+          uri = URI("http://#{domain_string}")
+        end
+        uri
+      rescue URI::InvalidURIError => e
+        if /(\d{,3}\.){3}\d{,3}:\d+/.match(domain_string)
+          uri = URI("http://#{domain_string}")
+        else
+          raise e
+        end
       end
-      uri
     end
   end
 end

--- a/spec/ailurus/utils_spec.rb
+++ b/spec/ailurus/utils_spec.rb
@@ -19,6 +19,21 @@ describe Ailurus::Utils do
       expect(test_uri.port).to eq(8080)
     end
 
+    it "handles bare IPv4 addresses" do
+      test_uri = Ailurus::Utils::get_absolute_uri("127.0.0.1")
+
+      expect(test_uri.scheme).to eq("http")
+      expect(test_uri.host).to eq("127.0.0.1")
+    end
+
+    it "handles bare IPv4 addresses with ports" do
+      test_uri = Ailurus::Utils::get_absolute_uri("127.0.0.1:8080")
+
+      expect(test_uri.scheme).to eq("http")
+      expect(test_uri.host).to eq("127.0.0.1")
+      expect(test_uri.port).to eq(8080)
+    end
+
     it "handles domains with HTTP" do
       test_uri = Ailurus::Utils::get_absolute_uri("http://panda.example.com")
 


### PR DESCRIPTION
Such as for a PANDA instance at `127.0.0.1:8000`, which Ruby's `URI` module doesn't handle properly.